### PR TITLE
Refactor: split main.py into scorer, optimizer, and clean main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,11 @@ python -m src.main --budget 1000000
 ```
 src/
 ├── __init__.py
-├── config.py        — Constants (EA 5% tax, target 100 players, margin bounds)
+├── config.py        — Constants (EA 5% tax, target 100 players)
 ├── futgg_client.py  — fut.gg API client (discovery, prices, sales, history)
-├── main.py          — Scoring, optimization, CLI, display, CSV export
+├── scorer.py        — OP sell scoring (price-at-time verified OP detection)
+├── optimizer.py     — Portfolio optimizer (efficiency sorting, swap loop, backfill)
+├── main.py          — CLI entry point, display, CSV export
 └── models.py        — Pydantic data models (Player, SaleRecord, PricePoint, etc.)
 ```
 

--- a/src/futgg_client.py
+++ b/src/futgg_client.py
@@ -4,11 +4,10 @@ fut.gg API client.
 Uses fut.gg's internal JSON API endpoints to fetch player data, prices,
 sales history, and live listings. No scraping needed — direct HTTP calls.
 
-Discovered endpoints:
-  - /api/fut/player-prices/26/{eaId}/         → prices, sales, listings, history
-  - /api/fut/player-prices/26/?ids=X,Y,Z      → batch current prices
-  - /api/fut/player-item-definitions/26/{eaId}/ → player card definition
-  - /api/fut/metarank/players/?ids=X,Y,Z       → meta rankings
+Endpoints:
+  - /api/fut/players/v2/26/          → paginated player list (price filterable)
+  - /api/fut/player-prices/26/{eaId}/ → prices, sales, listings, history
+  - /api/fut/player-item-definitions/26/{eaId}/ → card definition
 """
 
 from __future__ import annotations
@@ -24,7 +23,6 @@ from src.models import Player, PlayerMarketData, PricePoint, SaleRecord
 
 logger = logging.getLogger(__name__)
 
-# Position ID to string mapping (from fut.gg data)
 POSITION_MAP = {
     0: "GK", 1: "RWB", 2: "RB", 3: "CB", 4: "LB", 5: "LWB",
     6: "RDM", 7: "CDM", 8: "LDM", 9: "RM", 10: "CM", 11: "LM",
@@ -72,7 +70,7 @@ class FutGGClient:
         try:
             resp = await self.client.get(path)
             resp.raise_for_status()
-            await asyncio.sleep(0.15)  # light delay to be polite
+            await asyncio.sleep(0.15)
             return resp.json()
         except httpx.HTTPStatusError as e:
             logger.error(f"HTTP {e.response.status_code} for {path}")
@@ -81,127 +79,160 @@ class FutGGClient:
             logger.error(f"Request failed for {path}: {e}")
             return None
 
-    # ── Batch endpoints ──────────────────────────────────────────────
+    # ── API endpoints ──────────────────────────────────────────────
 
     async def get_batch_prices(self, ea_ids: list[int]) -> list[dict]:
-        """
-        Fetch current prices for multiple players at once.
-        Returns list of {eaId, price, isExtinct, ...}.
-        """
+        """Fetch current prices for multiple players at once."""
         if not ea_ids:
             return []
-
         ids_str = ",".join(str(i) for i in ea_ids)
         data = await self._get(f"/api/fut/player-prices/26/?ids={ids_str}")
-        if data and "data" in data:
-            return data["data"]
-        return []
-
-    async def get_batch_metaranks(self, ea_ids: list[int]) -> dict[int, float]:
-        """
-        Fetch meta ranking scores for multiple players.
-        Returns {eaId: score}.
-        """
-        if not ea_ids:
-            return {}
-
-        ids_str = ",".join(str(i) for i in ea_ids)
-        data = await self._get(f"/api/fut/metarank/players/?ids={ids_str}")
-        if data and "data" in data:
-            return {item["eaId"]: item.get("score", 0) for item in data["data"]}
-        return {}
-
-    # ── Individual player endpoints ──────────────────────────────────
+        return data["data"] if data and "data" in data else []
 
     async def get_player_prices(self, ea_id: int) -> Optional[dict]:
-        """
-        Fetch full price data for a single player card.
-
-        Returns dict with:
-          - currentPrice: {price, isExtinct, priceUpdatedAt, ...}
-          - completedAuctions: [{soldDate, soldPrice}, ...]
-          - liveAuctions: [{buyNowPrice, endDate, startingBid}, ...]
-          - history: [{date, price}, ...]  (daily/hourly price chart)
-          - momentum: {lowestBin, highestBin, currentBinMomentum, lastUpdates}
-          - overview: {averageBin, cheapestSale, discardValue, yesterdayAverageBin}
-          - priceRange: {minPrice, maxPrice}
-        """
+        """Fetch full price data for a single player card."""
         data = await self._get(f"/api/fut/player-prices/26/{ea_id}/")
-        if data and "data" in data:
-            return data["data"]
-        return None
+        return data["data"] if data and "data" in data else None
 
     async def get_player_definition(self, ea_id: int) -> Optional[dict]:
-        """
-        Fetch full card definition for a player.
-
-        Returns dict with: firstName, lastName, overall, position,
-        club, league, nation, rarity, face stats, attributes, etc.
-        """
+        """Fetch full card definition for a player."""
         data = await self._get(f"/api/fut/player-item-definitions/26/{ea_id}/")
-        if data and "data" in data:
-            return data["data"]
-        return None
+        return data["data"] if data and "data" in data else None
 
-    # ── High-level data assembly ─────────────────────────────────────
+    # ── Data assembly ──────────────────────────────────────────────
 
     async def get_player_market_data(self, ea_id: int) -> Optional[PlayerMarketData]:
-        """
-        Assemble full market data for a single player card.
-
-        Fetches both card definition and price data, then combines
-        into a PlayerMarketData object.
-        """
-        # Fetch definition and prices in parallel
+        """Fetch and assemble full market data for a single player card."""
         defn, prices = await asyncio.gather(
             self.get_player_definition(ea_id),
             self.get_player_prices(ea_id),
         )
-
         if not defn or not prices:
-            logger.warning(f"Missing data for ea_id={ea_id}")
             return None
 
-        # Build Player model
         player = self._build_player(defn)
+        current_bin = self._extract_current_bin(prices)
+        if not current_bin:
+            return None
 
-        # Current price
-        current_price = prices.get("currentPrice", {}) or {}
-        current_bin = current_price.get("price", 0) or 0
+        return PlayerMarketData(
+            player=player,
+            current_lowest_bin=current_bin,
+            listing_count=len(prices.get("liveAuctions", [])),
+            price_history=self._parse_price_history(ea_id, prices),
+            sales=self._parse_sales(ea_id, prices),
+            live_auction_prices=[a["buyNowPrice"] for a in prices.get("liveAuctions", [])],
+        )
 
-        # Live listings count
+    async def get_batch_market_data(
+        self, ea_ids: list[int], concurrency: int = 5,
+    ) -> list[Optional[PlayerMarketData]]:
+        """Fetch market data for multiple players concurrently."""
+        sem = asyncio.Semaphore(concurrency)
+
+        async def fetch_one(ea_id: int) -> Optional[PlayerMarketData]:
+            async with sem:
+                return await self.get_player_market_data(ea_id)
+
+        return await asyncio.gather(*[fetch_one(eid) for eid in ea_ids])
+
+    # ── Discovery ──────────────────────────────────────────────────
+
+    async def discover_players(
+        self, budget: int, max_pages: int = 999,
+        min_price: int = 0, max_price: int = 0,
+    ) -> list[dict]:
+        """Discover all tradeable player cards within a price range."""
+        if max_price <= 0:
+            max_price = int(budget * 0.10)
+        if min_price <= 0:
+            min_price = 1000
+
+        all_candidates = []
+        seen_ids: set[int] = set()
+
+        for page_num in range(1, max_pages + 1):
+            logger.info(f"Fetching player list page {page_num}...")
+            url = f"/api/fut/players/v2/26/?page={page_num}"
+            if min_price > 0:
+                url += f"&price__gte={min_price}"
+            if max_price > 0:
+                url += f"&price__lte={max_price}"
+            result = await self._get(url)
+
+            if not result or "data" not in result:
+                break
+            players = result["data"]
+            if not players:
+                break
+
+            ea_ids = []
+            player_map = {}
+            for p in players:
+                ea_id = self._extract_ea_id(p)
+                if ea_id and ea_id not in seen_ids:
+                    seen_ids.add(ea_id)
+                    ea_ids.append(ea_id)
+                    player_map[ea_id] = p
+
+            if ea_ids:
+                prices = await self.get_batch_prices(ea_ids)
+                price_map = {
+                    p["eaId"]: p["price"]
+                    for p in prices if p.get("price") is not None
+                }
+                for ea_id, player_data in player_map.items():
+                    price = price_map.get(ea_id, 0) or 0
+                    if min_price <= price <= max_price:
+                        player_data["ea_id"] = ea_id
+                        player_data["price"] = price
+                        all_candidates.append(player_data)
+
+            logger.info(
+                f"Page {page_num}: {len(players)} players, "
+                f"{len(all_candidates)} candidates so far"
+            )
+
+            if not result.get("next"):
+                break
+
+        logger.info(f"Discovery complete: {len(all_candidates)} candidates")
+        return all_candidates
+
+    # ── Private helpers ────────────────────────────────────────────
+
+    @staticmethod
+    def _extract_ea_id(player_data: dict) -> Optional[int]:
+        """Extract EA ID from a player list entry's slug."""
+        slug = player_data.get("slug", "")
+        ea_id_str = slug.split("-", 1)[-1] if "-" in slug else ""
+        try:
+            return int(ea_id_str)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _extract_current_bin(prices: dict) -> Optional[int]:
+        """Get the current lowest BIN from price data."""
         live_auctions = prices.get("liveAuctions", [])
-        listing_count = len(live_auctions)
-
-        # Actual lowest BIN from live listings + estimate OP listings
-        op_listing_count = 1
         if live_auctions:
-            actual_lowest_bin = min(a["buyNowPrice"] for a in live_auctions)
-            current_bin = actual_lowest_bin
+            return min(a["buyNowPrice"] for a in live_auctions)
 
-            # The API only shows ~16 listings, but there are many more on the market.
-            # Estimate OP listing count:
-            # - Count what % of visible listings are OP-priced
-            # - Scale up by total listing count (from the visible sample size ratio)
-            op_threshold = actual_lowest_bin * 1.03  # 3%+ above floor = OP
-            visible_op = sum(1 for a in live_auctions if a["buyNowPrice"] >= op_threshold)
-            visible_total = len(live_auctions)
+        current_price = prices.get("currentPrice", {}) or {}
+        price = current_price.get("price", 0) or 0
+        if price:
+            return int(price)
 
-            if visible_total > 0:
-                op_ratio = visible_op / visible_total
-                # The real market has many more listings than the ~16 we see.
-                # Conservative estimate: at least 5x what's visible for popular cards,
-                # use the ratio to scale. Minimum of visible_op + 1 (us).
-                estimated_total_listings = max(visible_total * 5, visible_total)
-                op_listing_count = max(int(estimated_total_listings * op_ratio), 1)
-            else:
-                op_listing_count = 1
+        overview = prices.get("overview", {}) or {}
+        return overview.get("averageBin", 0) or None
 
-        # Price history
-        price_history = []
+    @staticmethod
+    def _parse_price_history(ea_id: int, prices: dict) -> list[PricePoint]:
+        """Parse price history from the API response."""
+        points = []
         for point in prices.get("history", []):
             try:
-                price_history.append(PricePoint(
+                points.append(PricePoint(
                     resource_id=ea_id,
                     recorded_at=datetime.fromisoformat(
                         point["date"].replace("Z", "+00:00")
@@ -210,8 +241,11 @@ class FutGGClient:
                 ))
             except Exception:
                 continue
+        return points
 
-        # Completed sales
+    @staticmethod
+    def _parse_sales(ea_id: int, prices: dict) -> list[SaleRecord]:
+        """Parse completed sales from the API response."""
         sales = []
         for auction in prices.get("completedAuctions", []):
             try:
@@ -221,69 +255,16 @@ class FutGGClient:
                         auction["soldDate"].replace("Z", "+00:00")
                     ),
                     sold_price=auction["soldPrice"],
-                    # Use current BIN as approximation of floor at time of sale
-                    # The HOSS scorer will use price history to get more accurate floors
-                    lowest_bin_at_time=current_bin,
                 ))
             except Exception:
                 continue
-
-        # Ensure we have a valid price
-        if not current_bin or current_bin <= 0:
-            # Try getting from overview or history
-            overview = prices.get("overview", {}) or {}
-            current_bin = overview.get("averageBin", 0) or 0
-            if not current_bin and price_history:
-                current_bin = price_history[-1].lowest_bin
-
-        if not current_bin or current_bin <= 0:
-            return None
-
-        # Extract base player info for FUTBIN mapping
-        base_ea_id = defn.get("basePlayerEaId", 0) or 0
-        base_slug = defn.get("basePlayerSlug", "") or ""
-
-        # Store all live auction BIN prices and end times
-        live_prices = [a["buyNowPrice"] for a in live_auctions]
-        live_end_times = [a.get("endDate", "") for a in live_auctions]
-
-        return PlayerMarketData(
-            player=player,
-            current_lowest_bin=int(current_bin),
-            listing_count=listing_count,
-            op_listing_count=max(op_listing_count, 1),
-            price_history=price_history,
-            sales=sales,
-            live_auction_prices=live_prices,
-            live_auction_end_times=live_end_times,
-            base_player_ea_id=base_ea_id,
-            base_player_slug=base_slug,
-        )
-
-    async def get_batch_market_data(
-        self, ea_ids: list[int], concurrency: int = 5,
-    ) -> list[Optional[PlayerMarketData]]:
-        """
-        Fetch market data for multiple players concurrently.
-
-        Uses a semaphore to limit concurrent requests.
-        """
-        sem = asyncio.Semaphore(concurrency)
-
-        async def fetch_one(ea_id: int) -> Optional[PlayerMarketData]:
-            async with sem:
-                return await self.get_player_market_data(ea_id)
-
-        return await asyncio.gather(*[fetch_one(eid) for eid in ea_ids])
+        return sales
 
     def _build_player(self, defn: dict) -> Player:
         """Build a Player model from a card definition response."""
-        position_id = defn.get("position", 0)
-        position_str = POSITION_MAP.get(position_id, str(position_id))
-
+        position_str = POSITION_MAP.get(defn.get("position", 0), "?")
         rarity = defn.get("rarity", {})
         card_type = rarity.get("slug", "gold") if isinstance(rarity, dict) else "gold"
-
         club = defn.get("club", {})
         league = defn.get("league", {})
         nation = defn.get("nation", {})
@@ -304,103 +285,3 @@ class FutGGClient:
             defending=defn.get("faceDefending", 0),
             physical=defn.get("facePhysicality", 0),
         )
-
-    # ── Player discovery ─────────────────────────────────────────────
-
-    async def get_player_list_page(
-        self, page: int = 1,
-        min_price: int = 0, max_price: int = 0,
-    ) -> Optional[dict]:
-        """
-        Fetch a page of players from the trending listing API.
-
-        Uses the trending endpoint which supports price filtering:
-          price__gte=min, price__lte=max
-        """
-        url = f"/api/fut/players/v2/26/?page={page}"
-        params = []
-        if min_price > 0:
-            params.append(f"price__gte={min_price}")
-        if max_price > 0:
-            params.append(f"price__lte={max_price}")
-        if params:
-            url += "&" + "&".join(params)
-        return await self._get(url)
-
-    async def discover_players(
-        self, budget: int, max_pages: int = 999,
-        min_price: int = 0, max_price: int = 0,
-    ) -> list[dict]:
-        """
-        Discover tradeable player cards within budget.
-
-        Uses price-filtered API to only fetch relevant players.
-        max_price defaults to 10% of budget (no single card > 10% of budget).
-        min_price defaults to 1000 (ignore discard-value cards).
-        """
-        if max_price <= 0:
-            max_price = int(budget * 0.10)
-        if min_price <= 0:
-            min_price = 1000
-
-        all_candidates = []
-        seen_ids = set()
-
-        for page_num in range(1, max_pages + 1):
-            logger.info(f"Fetching player list page {page_num}...")
-            result = await self.get_player_list_page(
-                page_num, min_price=min_price, max_price=max_price,
-            )
-
-            if not result or "data" not in result:
-                break
-
-            players = result["data"]
-            if not players:
-                break
-
-            # Extract eaIds for batch price lookup
-            ea_ids = []
-            player_map = {}
-            for p in players:
-                slug = p.get("slug", "")
-                ea_id_str = slug.split("-", 1)[-1] if "-" in slug else ""
-                try:
-                    ea_id = int(ea_id_str)
-                except ValueError:
-                    continue
-
-                if ea_id in seen_ids:
-                    continue
-                seen_ids.add(ea_id)
-                ea_ids.append(ea_id)
-                player_map[ea_id] = p
-
-            # Batch fetch prices
-            if ea_ids:
-                prices = await self.get_batch_prices(ea_ids)
-                price_map = {
-                    p["eaId"]: p["price"]
-                    for p in prices
-                    if p.get("price") is not None
-                }
-
-                for ea_id, player_data in player_map.items():
-                    price = price_map.get(ea_id, 0) or 0
-                    if min_price <= price <= max_price:
-                        player_data["ea_id"] = ea_id
-                        player_data["price"] = price
-                        all_candidates.append(player_data)
-
-            logger.info(
-                f"Page {page_num}: {len(players)} players, "
-                f"{len(all_candidates)} candidates within budget so far"
-            )
-
-            # Stop if no next page
-            next_page = result.get("next")
-            if not next_page:
-                break
-
-        logger.info(f"Discovery complete: {len(all_candidates)} candidates")
-        return all_candidates

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,8 @@
 """
-FC26 OP Sell List Generator
+FC26 OP Sell List Generator.
 
-All data from fut.gg. Sell rate estimated from:
-- OP/normal ratio in live listings
-- Normal sales per hour (= normal listings per hour)
-- OP sales per hour from completed auctions
+Discovers players from fut.gg, scores them for OP selling potential,
+and outputs the optimal list for a given budget.
 
 Usage:
     python -m src.main --budget 1000000
@@ -14,19 +12,20 @@ from __future__ import annotations
 
 import asyncio
 import csv
+import io
 import logging
 import sys
-import io
 from datetime import datetime
+
 import click
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 from rich.text import Text
 
-from src.config import EA_TAX_RATE, TARGET_PLAYER_COUNT
 from src.futgg_client import FutGGClient
-from src.models import PlayerMarketData
+from src.scorer import score_player
+from src.optimizer import optimize_portfolio
 
 if sys.platform == "win32":
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
@@ -36,117 +35,17 @@ console = Console(force_terminal=True)
 logger = logging.getLogger("op-seller")
 
 
-def score_player(md: PlayerMarketData) -> dict | None:
-    """
-    Score a player for OP selling using only fut.gg data.
-
-    Key metric: how many OP sales in the data window, extrapolated to 24h.
-    """
-    buy_price = md.current_lowest_bin
-    if buy_price <= 0:
-        return None
-
-    sales = md.sales
-    live_prices = md.live_auction_prices
-
-    if len(sales) < 5 or len(live_prices) < 20:
-        return None
-
-    # Time span of sales data
-    sorted_sales = sorted(sales, key=lambda s: s.sold_at)
-    time_span_hrs = (sorted_sales[-1].sold_at - sorted_sales[0].sold_at).total_seconds() / 3600
-    if time_span_hrs < 0.5:
-        time_span_hrs = 0.5
-
-    total_sales = len(sales)
-    sales_per_hour = total_sales / time_span_hrs
-    if sales_per_hour < 7:
-        return None
-
-    # Build price-at-time lookup from history
-    price_by_hour = {}
-    for point in md.price_history:
-        hour_key = point.recorded_at.strftime("%Y-%m-%dT%H")
-        price_by_hour[hour_key] = point.lowest_bin
-
-    def get_price_at_time(sale_time):
-        """Get price at sale time, falling back to nearest available hour."""
-        from datetime import timedelta
-        hour_key = sale_time.strftime("%Y-%m-%dT%H")
-        if hour_key in price_by_hour:
-            return price_by_hour[hour_key]
-        # Try nearby hours (±1, ±2)
-        for delta in [-1, 1, -2, 2]:
-            nearby = (sale_time + timedelta(hours=delta)).strftime("%Y-%m-%dT%H")
-            if nearby in price_by_hour:
-                return price_by_hour[nearby]
-        return buy_price  # last resort
-
-    # Try each margin — pick the one with the highest net profit
-    # that still has at least 3 REAL OP sales (vs price at time of sale)
-    best = None
-
-    for margin_pct in [40, 35, 30, 25, 20, 15, 10, 8, 5, 3]:
-        margin = margin_pct / 100.0
-
-        # Count OP sales using price AT THE TIME, not current BIN
-        op_sales = 0
-        for s in sales:
-            price_at_time = get_price_at_time(s.sold_at)
-            threshold = int(price_at_time * (1 + margin))
-            if s.sold_price >= threshold:
-                op_sales += 1
-
-        if op_sales < 3:
-            continue
-
-        # Calculate profit based on CURRENT price (what we'd buy/sell at now)
-        sell_price = int(buy_price * (1 + margin))
-        ea_tax = int(sell_price * EA_TAX_RATE)
-        net_profit = sell_price - ea_tax - buy_price
-        if net_profit <= 0:
-            continue
-
-        op_sales_per_24h = op_sales / time_span_hrs * 24
-        op_ratio = op_sales / total_sales
-
-        # Pick highest net profit (we iterate from highest margin down)
-        if best is None:
-            best = {
-                "margin": margin,
-                "margin_pct": margin_pct,
-                "sell_price": sell_price,
-                "net_profit": net_profit,
-                "op_sales": op_sales,
-                "total_sales": total_sales,
-                "op_ratio": op_ratio,
-                "op_sales_24h": round(op_sales_per_24h, 1),
-                "time_span_hrs": round(time_span_hrs, 1),
-                "sales_per_hour": round(sales_per_hour, 1),
-            }
-            break  # highest margin with 3+ OP sales = best profit
-
-    if not best:
-        return None
-
-    return {
-        "player": md.player,
-        "buy_price": buy_price,
-        **best,
-    }
-
-
 async def run(budget: int, verbose: bool) -> None:
-    """discover → fetch → score → optimize → display."""
+    """Main pipeline: discover → fetch → score → optimize → display."""
     client = FutGGClient()
     await client.start()
 
     try:
-        # ── Step 1: Discover all players in price range ──────────────
+        # ── Step 1: Discover players in price range ──────────────
         max_price = int(budget * 0.10)
         min_price = int(budget * 0.005)
         console.print(
-            f"\n[bold]Discovering ALL players {min_price:,}–{max_price:,} "
+            f"\n[bold]Discovering players {min_price:,}–{max_price:,} "
             f"(budget: {budget:,})...[/bold]"
         )
         candidates = await client.discover_players(
@@ -157,121 +56,36 @@ async def run(budget: int, verbose: bool) -> None:
             console.print("[red]No candidates found.[/red]")
             return
 
-        # ── Step 2: Fetch market data (batched) ──────────────────────
+        # ── Step 2: Fetch market data ────────────────────────────
         console.print("[bold]Fetching market data...[/bold]")
-        ea_ids = [c.get("ea_id", 0) for c in candidates if c.get("ea_id")]
-        all_md = []
-        for i in range(0, len(ea_ids), 10):
-            batch = ea_ids[i:i + 10]
-            if (i // 10) % 10 == 0 or i == 0:
-                console.print(f"  [{min(i+10, len(ea_ids))}/{len(ea_ids)}]")
-            results = await client.get_batch_market_data(batch, concurrency=10)
-            all_md.extend(results)
+        ea_ids = [c["ea_id"] for c in candidates if c.get("ea_id")]
+        all_md = await client.get_batch_market_data(ea_ids, concurrency=10)
 
-        valid = [(eid, md) for eid, md in zip(ea_ids, all_md)
-                 if md and md.current_lowest_bin > 0]
-        console.print(f"Got data for [green]{len(valid)}[/green] players\n")
+        valid_md = [md for md in all_md if md and md.current_lowest_bin > 0]
+        console.print(f"Got data for [green]{len(valid_md)}[/green] players\n")
 
-        # ── Step 3: Score all players ────────────────────────────────
+        # ── Step 3: Score ────────────────────────────────────────
         console.print("[bold]Scoring players...[/bold]")
-        scored = []
-        for ea_id, md in valid:
-            result = score_player(md)
-            if result:
-                scored.append(result)
-
+        scored = [s for md in valid_md if (s := score_player(md))]
         console.print(f"Scored [green]{len(scored)}[/green] viable players\n")
 
-        # ── Step 4: Sort by OP sales per 24h ────────────────────────
+        # ── Step 4: Optimize portfolio ───────────────────────────
         console.print("[bold]Optimizing portfolio...[/bold]")
-        # Sort by expected profit per coin invested
-        # = (net_profit × op_ratio) / buy_price
-        # This favors cards where you get the most expected return per coin
-        for s in scored:
-            s["expected_profit"] = s["net_profit"] * s["op_ratio"]
-            s["efficiency"] = s["expected_profit"] / s["buy_price"] if s["buy_price"] > 0 else 0
-        scored.sort(key=lambda s: s["efficiency"], reverse=True)
+        selected = optimize_portfolio(scored, budget)
 
-        selected = []
-        total_used = 0
-        used_ids = set()
-
-        for entry in scored:
-            if len(selected) >= TARGET_PLAYER_COUNT:
-                break
-            pid = entry["player"].resource_id
-            if pid in used_ids:
-                continue
-            cost = entry["buy_price"]
-            if total_used + cost > budget:
-                continue
-            selected.append(entry)
-            used_ids.add(pid)
-            total_used += cost
-
-        # Swap loop
-        swaps = 0
-        while len(selected) < TARGET_PLAYER_COUNT and swaps < 100:
-            if not selected:
-                break
-            exp_idx = max(range(len(selected)), key=lambda i: selected[i]["buy_price"])
-            expensive = selected[exp_idx]
-            freed = expensive["buy_price"]
-            removed_ep = expensive["expected_profit"]
-
-            replacements = []
-            repl_ep = 0
-            repl_cost = 0
-            temp_used = {s["player"].resource_id for s in selected} - {expensive["player"].resource_id}
-
-            for s in scored:
-                pid = s["player"].resource_id
-                if pid in temp_used:
-                    continue
-                if repl_cost + s["buy_price"] <= freed:
-                    replacements.append(s)
-                    repl_ep += s["expected_profit"]
-                    repl_cost += s["buy_price"]
-                    temp_used.add(pid)
-
-            if len(replacements) >= 2 and repl_ep > removed_ep:
-                used_ids.discard(expensive["player"].resource_id)
-                selected.pop(exp_idx)
-                total_used -= freed
-                for r in replacements:
-                    selected.append(r)
-                    used_ids.add(r["player"].resource_id)
-                    total_used += r["buy_price"]
-                swaps += 1
-            else:
-                break
-
-        # Backfill
-        remaining = budget - total_used
-        for s in scored:
-            if len(selected) >= TARGET_PLAYER_COUNT:
-                break
-            pid = s["player"].resource_id
-            if pid in used_ids:
-                continue
-            if s["buy_price"] <= remaining:
-                selected.append(s)
-                used_ids.add(pid)
-                total_used += s["buy_price"]
-                remaining -= s["buy_price"]
-
-        selected.sort(key=lambda s: s["expected_profit"], reverse=True)
-
-        # ── Step 5: Display + Export ─────────────────────────────────
+        # ── Step 5: Display + Export ─────────────────────────────
+        total_used = sum(s["buy_price"] for s in selected)
         display_results(selected, budget, total_used)
-        csv_path = export_csv(selected, budget, total_used)
+
+        csv_path = export_csv(selected)
         console.print(f"\n[bold green]Exported:[/bold green] {csv_path}")
 
     finally:
         await client.stop()
 
 
-def display_results(selected, budget, total_used):
+def display_results(selected: list[dict], budget: int, total_used: int) -> None:
+    """Display portfolio summary and player table."""
     if not selected:
         console.print("[red]No players selected.[/red]")
         return
@@ -283,7 +97,8 @@ def display_results(selected, budget, total_used):
     summary.append(f"Budget: {budget:,}", style="bold")
     summary.append(f"  |  Used: {total_used:,}")
     summary.append(f"  |  Profit/sell: {total_profit:,}", style="bold green")
-    summary.append(f" ({total_profit/total_used:.1%})" if total_used else "")
+    if total_used:
+        summary.append(f" ({total_profit / total_used:.1%})")
     summary.append(f"\nExpected profit: {total_expected:,.0f}", style="bold cyan")
     summary.append(f"  |  Players: {len(selected)}")
     console.print(Panel(summary, title="OP Sell Portfolio", border_style="green"))
@@ -319,7 +134,8 @@ def display_results(selected, budget, total_used):
     console.print(table)
 
 
-def export_csv(selected, budget, total_used):
+def export_csv(selected: list[dict]) -> str:
+    """Export portfolio to CSV file. Returns the file path."""
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     path = f"op_sell_list_{ts}.csv"
     with open(path, "w", newline="", encoding="utf-8") as f:
@@ -327,17 +143,18 @@ def export_csv(selected, budget, total_used):
         w.writerow([
             "Rank", "Player", "Rating", "Position", "League", "Club",
             "Buy", "Sell", "Profit", "Profit%", "Margin",
-            "OP Sales/24h", "OP Sales", "Total Sales", "OP Ratio",
-            "Sales/hr", "Data Span",
+            "Expected Profit", "OP Sales", "Total Sales", "OP Ratio",
+            "OP Sales/24h", "Sales/hr", "Data Span",
         ])
         for i, s in enumerate(selected):
             p = s["player"]
             w.writerow([
-                i+1, p.name, p.rating, p.position, p.league, p.club,
+                i + 1, p.name, p.rating, p.position, p.league, p.club,
                 s["buy_price"], s["sell_price"], s["net_profit"],
-                f"{s['net_profit']/s['buy_price']:.2%}", f"{s['margin_pct']}%",
-                f"{s['op_sales_24h']:.0f}", s["op_sales"], s["total_sales"],
-                f"{s['op_ratio']:.2%}", s["sales_per_hour"],
+                f"{s['net_profit'] / s['buy_price']:.2%}", f"{s['margin_pct']}%",
+                f"{s['expected_profit']:.0f}",
+                s["op_sales"], s["total_sales"], f"{s['op_ratio']:.2%}",
+                f"{s['op_sales_24h']:.0f}", s["sales_per_hour"],
                 f"{s['time_span_hrs']:.1f}h",
             ])
     return path

--- a/src/models.py
+++ b/src/models.py
@@ -31,7 +31,6 @@ class SaleRecord(BaseModel):
     resource_id: int
     sold_at: datetime
     sold_price: int
-    lowest_bin_at_time: int
 
 
 class PricePoint(BaseModel):
@@ -39,8 +38,6 @@ class PricePoint(BaseModel):
     resource_id: int
     recorded_at: datetime
     lowest_bin: int
-    median_bin: Optional[int] = None
-    listing_count: Optional[int] = None
 
 
 class PlayerMarketData(BaseModel):
@@ -48,10 +45,6 @@ class PlayerMarketData(BaseModel):
     player: Player
     current_lowest_bin: int
     listing_count: int
-    op_listing_count: int
     price_history: list[PricePoint]
     sales: list[SaleRecord]
     live_auction_prices: list[int] = []
-    live_auction_end_times: list[str] = []
-    base_player_ea_id: int = 0
-    base_player_slug: str = ""

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -1,0 +1,99 @@
+"""
+Portfolio optimizer.
+
+Selects the best players to fill the budget, maximizing total expected
+profit. Uses efficiency sorting (expected_profit / buy_price) to favor
+cheaper cards with decent OP ratios. Swap loop replaces expensive cards
+with multiple cheaper alternatives when profitable.
+"""
+
+from __future__ import annotations
+
+from src.config import TARGET_PLAYER_COUNT
+
+
+def optimize_portfolio(scored: list[dict], budget: int) -> list[dict]:
+    """
+    Select up to TARGET_PLAYER_COUNT players that fit within budget,
+    maximizing total expected profit.
+
+    Returns the selected list sorted by expected profit descending.
+    """
+    # Add efficiency metric
+    for s in scored:
+        s["efficiency"] = s["expected_profit"] / s["buy_price"] if s["buy_price"] > 0 else 0
+
+    # Greedy fill by efficiency
+    scored.sort(key=lambda s: s["efficiency"], reverse=True)
+
+    selected = []
+    total_used = 0
+    used_ids: set[int] = set()
+
+    for entry in scored:
+        if len(selected) >= TARGET_PLAYER_COUNT:
+            break
+        pid = entry["player"].resource_id
+        if pid in used_ids:
+            continue
+        cost = entry["buy_price"]
+        if total_used + cost > budget:
+            continue
+        selected.append(entry)
+        used_ids.add(pid)
+        total_used += cost
+
+    # Swap loop: replace the most expensive card with cheaper alternatives
+    # if they collectively produce more expected profit
+    swaps = 0
+    while len(selected) < TARGET_PLAYER_COUNT and swaps < 100:
+        if not selected:
+            break
+
+        exp_idx = max(range(len(selected)), key=lambda i: selected[i]["buy_price"])
+        expensive = selected[exp_idx]
+        freed = expensive["buy_price"]
+
+        replacements = []
+        repl_ep = 0
+        repl_cost = 0
+        temp_used = {s["player"].resource_id for s in selected} - {expensive["player"].resource_id}
+
+        for s in scored:
+            pid = s["player"].resource_id
+            if pid in temp_used:
+                continue
+            if repl_cost + s["buy_price"] <= freed:
+                replacements.append(s)
+                repl_ep += s["expected_profit"]
+                repl_cost += s["buy_price"]
+                temp_used.add(pid)
+
+        if len(replacements) >= 2 and repl_ep > expensive["expected_profit"]:
+            used_ids.discard(expensive["player"].resource_id)
+            selected.pop(exp_idx)
+            total_used -= freed
+            for r in replacements:
+                selected.append(r)
+                used_ids.add(r["player"].resource_id)
+                total_used += r["buy_price"]
+            swaps += 1
+        else:
+            break
+
+    # Backfill remaining budget
+    remaining = budget - total_used
+    for s in scored:
+        if len(selected) >= TARGET_PLAYER_COUNT:
+            break
+        pid = s["player"].resource_id
+        if pid in used_ids:
+            continue
+        if s["buy_price"] <= remaining:
+            selected.append(s)
+            used_ids.add(pid)
+            total_used += s["buy_price"]
+            remaining -= s["buy_price"]
+
+    selected.sort(key=lambda s: s["expected_profit"], reverse=True)
+    return selected

--- a/src/scorer.py
+++ b/src/scorer.py
@@ -1,0 +1,105 @@
+"""
+OP sell scorer.
+
+For each player, finds the best OP margin by checking how many sales
+happened above market price AT THE TIME of the sale. Requires 3+ verified
+OP sales at a given margin for it to count.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from src.config import EA_TAX_RATE
+from src.models import PlayerMarketData
+
+# Margins to try, highest first (we pick the first with 3+ OP sales)
+MARGINS = [40, 35, 30, 25, 20, 15, 10, 8, 5, 3]
+MIN_OP_SALES = 3
+MIN_TOTAL_SALES = 5
+MIN_LIVE_LISTINGS = 20
+MIN_SALES_PER_HOUR = 7
+
+
+def score_player(md: PlayerMarketData) -> dict | None:
+    """
+    Score a player for OP selling.
+
+    Returns a dict with scoring data, or None if the player isn't viable.
+    Picks the highest margin that has 3+ verified OP sales (checked
+    against the market price at the time each sale happened).
+    """
+    buy_price = md.current_lowest_bin
+    if buy_price <= 0:
+        return None
+
+    if len(md.sales) < MIN_TOTAL_SALES or len(md.live_auction_prices) < MIN_LIVE_LISTINGS:
+        return None
+
+    # Time span of sales data
+    sorted_sales = sorted(md.sales, key=lambda s: s.sold_at)
+    time_span_hrs = (sorted_sales[-1].sold_at - sorted_sales[0].sold_at).total_seconds() / 3600
+    if time_span_hrs < 0.5:
+        time_span_hrs = 0.5
+
+    total_sales = len(md.sales)
+    sales_per_hour = total_sales / time_span_hrs
+    if sales_per_hour < MIN_SALES_PER_HOUR:
+        return None
+
+    # Build price-at-time lookup from hourly history
+    price_by_hour = {
+        point.recorded_at.strftime("%Y-%m-%dT%H"): point.lowest_bin
+        for point in md.price_history
+    }
+
+    # Try each margin (highest first) — pick the first with 3+ OP sales
+    for margin_pct in MARGINS:
+        margin = margin_pct / 100.0
+
+        # Count OP sales verified against price at time of sale
+        op_sales = 0
+        for s in md.sales:
+            price_at_time = _get_price_at_time(s.sold_at, price_by_hour, buy_price)
+            if s.sold_price >= int(price_at_time * (1 + margin)):
+                op_sales += 1
+
+        if op_sales < MIN_OP_SALES:
+            continue
+
+        # Calculate profit at current price
+        sell_price = int(buy_price * (1 + margin))
+        ea_tax = int(sell_price * EA_TAX_RATE)
+        net_profit = sell_price - ea_tax - buy_price
+        if net_profit <= 0:
+            continue
+
+        op_ratio = op_sales / total_sales
+        return {
+            "player": md.player,
+            "buy_price": buy_price,
+            "sell_price": sell_price,
+            "net_profit": net_profit,
+            "margin_pct": margin_pct,
+            "op_sales": op_sales,
+            "total_sales": total_sales,
+            "op_ratio": op_ratio,
+            "op_sales_24h": round(op_sales / time_span_hrs * 24, 1),
+            "expected_profit": net_profit * op_ratio,
+            "sales_per_hour": round(sales_per_hour, 1),
+            "time_span_hrs": round(time_span_hrs, 1),
+        }
+
+    return None
+
+
+def _get_price_at_time(sale_time, price_by_hour: dict, fallback: int) -> int:
+    """Get market price at sale time, interpolating to nearest available hour."""
+    hour_key = sale_time.strftime("%Y-%m-%dT%H")
+    if hour_key in price_by_hour:
+        return price_by_hour[hour_key]
+    for delta in [-1, 1, -2, 2]:
+        nearby = (sale_time + timedelta(hours=delta)).strftime("%Y-%m-%dT%H")
+        if nearby in price_by_hour:
+            return price_by_hour[nearby]
+    return fallback


### PR DESCRIPTION
Architecture changes:
- scorer.py: OP sell scoring logic with price-at-time verification
- optimizer.py: Portfolio optimization (efficiency sort, swap loop, backfill)
- main.py: Now only CLI, display, CSV export — delegates to scorer/optimizer

Cleanup:
- models.py: Remove unused fields (op_listing_count, live_auction_end_times, base_player_ea_id, base_player_slug, lowest_bin_at_time on SaleRecord)
- futgg_client.py: Remove dead OP listing estimation code, extract helper methods (_extract_ea_id, _extract_current_bin, _parse_price_history, _parse_sales), inline get_player_list_page into discover_players
- config.py: Only EA_TAX_RATE and TARGET_PLAYER_COUNT remain
- Fix: get_batch_market_data called directly instead of manual chunking
- Stale docstrings updated throughout